### PR TITLE
Feature: IR generation

### DIFF
--- a/Aeternals_ideas.txt
+++ b/Aeternals_ideas.txt
@@ -1,0 +1,3 @@
+in typechecker rewrite `BinOp`s and `UnOp`s that use non-builtin-operators into `Call`s
+
+also resolve generics here by mangling the names

--- a/compiler_flow.txt
+++ b/compiler_flow.txt
@@ -3,4 +3,4 @@ $: currently implementing
 
 IR GENERATOR: implement register sizing
 
-filename -> [reader] -> [lexer] -> [parser] -> [localizer] -> [!importer!] -> [typechecker] -> [flow analyzer] -> [$ir generator$]
+filename -> [reader] -> [lexer] -> [parser] -> [localizer] -> [!importer!] -> [typechecker] -> [!flattener!] -> [flow analyzer] -> [$ir generator$]

--- a/compiler_flow.txt
+++ b/compiler_flow.txt
@@ -1,4 +1,6 @@
 !: not implemented yet
 $: currently implementing
 
+IR GENERATOR: implement register sizing
+
 filename -> [reader] -> [lexer] -> [parser] -> [localizer] -> [!importer!] -> [typechecker] -> [flow analyzer] -> [$ir generator$]

--- a/compiler_flow.txt
+++ b/compiler_flow.txt
@@ -1,0 +1,4 @@
+!: not implemented yet
+$: currently implementing
+
+filename -> [reader] -> [lexer] -> [parser] -> [localizer] -> [!importer!] -> [typechecker] -> [flow analyzer] -> [$ir generator$]

--- a/csharp_compiler/Compiler.cs
+++ b/csharp_compiler/Compiler.cs
@@ -62,7 +62,13 @@ public class Compiler {
 		PrettyPrint(AST);
 
 		IrList instructions = GetIR(file);
-		foreach (var instr in instructions.Instructions) Console.WriteLine(instr);
+		var functionsReversed = instructions.Functions.Select(pair => (pair.Value, pair.Key)).ToDictionary(p => p.Item1, p => p.Item2);
+		int i = 0;
+		foreach (var instr in instructions.Instructions) {
+			if (functionsReversed.ContainsKey(i)) Console.WriteLine($"{functionsReversed[i]}:");
+			i++;
+			Console.WriteLine("    " + instr);
+		}
 		foreach (var pair in instructions.Functions) Console.WriteLine($"{pair.Key}: {pair.Value}");
 	}
 

--- a/csharp_compiler/Compiler.cs
+++ b/csharp_compiler/Compiler.cs
@@ -34,8 +34,8 @@ public class Compiler {
 	private Dictionary<string, TokenList>          lexedFiles     = new();
 	private Dictionary<string, FileNode>           parsedFiles    = new();
 	private Dictionary<string, LocalizedFileNode>  localizedFiles = new();
-	private Dictionary<string, LocalizedFileNode>  typedFiles     = new();
-	private Dictionary<string, LocalizedFileNode>  analyzedFiles  = new();
+	private Dictionary<string, TypedFileNode>      typedFiles     = new();
+	private Dictionary<string, TypedFileNode>      analyzedFiles  = new();
 	private Dictionary<string, IrList>             generatedFiles = new();
 
 	private static T Memoize<T>(string file, Dictionary<string, T> memory, Func<string, T> generator) {
@@ -58,7 +58,7 @@ public class Compiler {
 		TokenList tokens = GetTokens(file);
 		foreach (var token in tokens) Console.WriteLine(token);
 
-		LocalizedFileNode AST = GetAnalyzedAST(file);
+		TypedFileNode AST = GetAnalyzedAST(file);
 		PrettyPrint(AST);
 
 		IrList instructions = GetIR(file);
@@ -141,10 +141,10 @@ public class Compiler {
 	public LocalizedFileNode GetLocalizedAST(string file) =>
 		Memoize(file, localizedFiles, f => localizer.Localize(GetAST(f)));
 
-	public LocalizedFileNode GetTypedAST(string file) =>
+	public TypedFileNode GetTypedAST(string file) =>
 		Memoize(file, typedFiles, f => typeChecker.Check(GetLocalizedAST(f)));
 
-	public LocalizedFileNode GetAnalyzedAST(string file) =>
+	public TypedFileNode GetAnalyzedAST(string file) =>
 		Memoize(file, analyzedFiles, f => flowAnalyzer.Analyze(GetTypedAST(f)));
 
 	public IrList GetIR(string file) =>

--- a/csharp_compiler/FlowAnalysis/FlowAnalyzer.cs
+++ b/csharp_compiler/FlowAnalysis/FlowAnalyzer.cs
@@ -56,6 +56,7 @@ public class FlowAnalyzer {
 				// trivial, no impact on control flow
 				case DeclareVarNode:
 				case DestructureNode:
+				case NoopStatementNode: // this one literally does nothing
 					break;
 				default:
 					throw new Exception($"Analyze(ctx, {statement.GetType().Name}) not yet implemented");

--- a/csharp_compiler/FlowAnalysis/FlowAnalyzer.cs
+++ b/csharp_compiler/FlowAnalysis/FlowAnalyzer.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 
 using Nyapl.Parsing.Tree;
 
+using Nyapl.Localizing;
+
 namespace Nyapl.FlowAnalysis;
 
 public class FlowAnalyzer {

--- a/csharp_compiler/FlowAnalysis/FlowAnalyzer.cs
+++ b/csharp_compiler/FlowAnalysis/FlowAnalyzer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 using Nyapl.Parsing.Tree;
 
-using Nyapl.Localizing;
+using Nyapl.Typing;
 
 namespace Nyapl.FlowAnalysis;
 
@@ -73,7 +73,7 @@ public class FlowAnalyzer {
 		if (!ctx.Returns) ctx.Errors.Add(new FlowError(function.Location, "Not all code paths return"));
 	}
 
-	public LocalizedFileNode Analyze(LocalizedFileNode file) {
+	public TypedFileNode Analyze(TypedFileNode file) {
 		var ctx = new Context();
 		// the only things in a file with flow currently are Functions, which (currently) only have one flow path, will still write the code to theoretically support multiple flow paths, might need to rewrite parts of this
 		foreach (var function in file.Functions) {

--- a/csharp_compiler/IrGeneration/IrGenerator.cs
+++ b/csharp_compiler/IrGeneration/IrGenerator.cs
@@ -16,7 +16,7 @@ public class IrGenerator {
 			case IntLiteralNode integer: {
 					instructions.Add(new(
 						IrInstr.IrKind.IntLiteral,
-						ctx.GetNewRegister(),
+						ctx.GetNewRegister(0),
 						integer.Value
 					));
 				} break;
@@ -24,7 +24,7 @@ public class IrGenerator {
 						var index = Array.IndexOf(ctx.Platform.Intrinsics.Keys.ToArray(), intrinsic.Name);
 						instructions.Add(new(
 							IrInstr.IrKind.LoadIntrinsic,
-							ctx.GetNewRegister(),
+							ctx.GetNewRegister(1),
 							(ulong)index
 						));
 					} break;
@@ -34,14 +34,14 @@ public class IrGenerator {
 						// we are looking up a function
 						instructions.Add(new(
 							IrInstr.IrKind.LoadFunction,
-							ctx.GetNewRegister(),
+							ctx.GetNewRegister(2),
 							ctx.GetFunction(lookup.Name)
 						));
 					} else {
 						// variable found
 						instructions.Add(new(
 							IrInstr.IrKind.Copy,
-							ctx.GetNewRegister(),
+							ctx.GetNewRegister(3),
 							register
 						));
 					}
@@ -63,7 +63,7 @@ public class IrGenerator {
 					}
 					instructions.Add(new(
 						IrInstr.IrKind.Call,
-						ctx.GetNewRegister(),
+						ctx.GetNewRegister(4),
 						baseReg
 					));
 				} break;
@@ -76,7 +76,7 @@ public class IrGenerator {
 						case BinOpKind.Multiply:
 							instructions.Add(new(
 								IrInstr.IrKind.Multiply,
-								ctx.GetNewRegister(),
+								ctx.GetNewRegister(5),
 								leftReg,
 								rightReg
 							));
@@ -84,7 +84,7 @@ public class IrGenerator {
 						case BinOpKind.Add:
 							instructions.Add(new(
 								IrInstr.IrKind.Add,
-								ctx.GetNewRegister(),
+								ctx.GetNewRegister(6),
 								leftReg,
 								rightReg
 							));
@@ -135,7 +135,7 @@ public class IrGenerator {
 		foreach (var param in function.Parameters) {
 			instructions.Add(new(
 				IrInstr.IrKind.LoadArgument,
-				ctx.GetNewRegister(),
+				ctx.GetNewRegister(7),
 				i++
 			));
 			ctx.SetVariable(param.Name, ctx.GetPreviousRegister());
@@ -173,10 +173,11 @@ public class IrGenerator {
 		public string[] Functions { get; }
 
 		private ulong currentRegister = 0;
+		private ulong previousRegister = 0;
 		private Dictionary<string, ulong> variables = new();
 
-		public ulong GetNewRegister() => currentRegister++;
-		public ulong GetPreviousRegister() => currentRegister - 1;
+		public ulong GetNewRegister(ushort size) => previousRegister = currentRegister++ | (ulong)size << 48;
+		public ulong GetPreviousRegister() => previousRegister;
 
 		public ulong GetFunction(string name) => (ulong)Array.IndexOf(Functions, name);
 

--- a/csharp_compiler/IrGeneration/IrGenerator.cs
+++ b/csharp_compiler/IrGeneration/IrGenerator.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+using Nyapl.Parsing.Tree;
+
+using Nyapl.Localizing;
+
+namespace Nyapl.IrGeneration;
+
+public class IrGenerator {
+	public IEnumerable<IrInstr> Generate(FunctionNode function) {
+		yield break;
+	}
+
+	public IrList Generate(LocalizedFileNode file) {
+		List<IrInstr> instructions = new();
+
+		Dictionary<string, int> functions = new();
+
+		foreach(var function in file.Functions) {
+			int fnIdx = instructions.Count;
+			instructions.AddRange(Generate(function));
+			functions[function.Name] = fnIdx;
+		}
+
+		return new(file.Platform, instructions.AsReadOnly(), functions.AsReadOnly());
+	}
+}

--- a/csharp_compiler/IrGeneration/IrGenerator.cs
+++ b/csharp_compiler/IrGeneration/IrGenerator.cs
@@ -24,7 +24,7 @@ public class IrGenerator {
 						var index = Array.IndexOf(ctx.Platform.Intrinsics.Keys.ToArray(), intrinsic.Name);
 						instructions.Add(new(
 							IrInstr.IrKind.LoadIntrinsic,
-							ctx.GetNewRegister(1),
+							ctx.GetNewRegister(ctx.Platform.PointerSize),
 							(ulong)index
 						));
 					} break;
@@ -34,7 +34,7 @@ public class IrGenerator {
 						// we are looking up a function
 						instructions.Add(new(
 							IrInstr.IrKind.LoadFunction,
-							ctx.GetNewRegister(2),
+							ctx.GetNewRegister(ctx.Platform.PointerSize),
 							ctx.GetFunction(lookup.Name)
 						));
 					} else {

--- a/csharp_compiler/IrGeneration/IrGenerator.cs
+++ b/csharp_compiler/IrGeneration/IrGenerator.cs
@@ -201,6 +201,7 @@ public class IrGenerator {
 		List<IrInstr> instructions = new();
 
 		switch (statement) {
+			case NoopStatementNode: break; // NOP
 			case DeclareVarNode v: {
 				instructions.AddRange(Generate(ctx, v.Expression));
 				ctx.SetVariable(v.Name, ctx.GetPreviousRegister());

--- a/csharp_compiler/IrGeneration/IrGenerator.cs
+++ b/csharp_compiler/IrGeneration/IrGenerator.cs
@@ -108,6 +108,22 @@ public class IrGenerator {
 								rightReg
 							));
 							break;
+						case BinOpKind.Divide:
+							instructions.Add(new(
+								IrInstr.IrKind.Divide,
+								ctx.GetNewRegister(size),
+								leftReg,
+								rightReg
+							));
+							break;
+						case BinOpKind.Modulo:
+							instructions.Add(new(
+								IrInstr.IrKind.Modulo,
+								ctx.GetNewRegister(size),
+								leftReg,
+								rightReg
+							));
+							break;
 						case BinOpKind.Add:
 							instructions.Add(new(
 								IrInstr.IrKind.Add,
@@ -116,8 +132,62 @@ public class IrGenerator {
 								rightReg
 							));
 							break;
+						case BinOpKind.Subtract:
+							instructions.Add(new(
+								IrInstr.IrKind.Subtract,
+								ctx.GetNewRegister(size),
+								leftReg,
+								rightReg
+							));
+							break;
+						case BinOpKind.Equal:
+							instructions.Add(new(
+								IrInstr.IrKind.Equal,
+								ctx.GetNewRegister(size),
+								leftReg,
+								rightReg
+							));
+							break;
+						case BinOpKind.NotEq:
+							instructions.Add(new(
+								IrInstr.IrKind.NotEq,
+								ctx.GetNewRegister(size),
+								leftReg,
+								rightReg
+							));
+							break;
 						default:
 							throw new Exception($"Generating `BinOpKind.{bin.OP}` not implemented yet");
+					}
+				} break;
+			case UnOpNode un: {
+					var size = ctx.TypeCtx.GetSize(un.Type!);
+					instructions.AddRange(Generate(ctx, un.Expr));
+					var reg = ctx.GetPreviousRegister();
+					switch (un.OP) {
+						case UnOpKind.Not:
+							instructions.Add(new(
+								IrInstr.IrKind.Not,
+								ctx.GetNewRegister(size),
+								reg
+							));
+							break;
+						case UnOpKind.Negative:
+							instructions.Add(new(
+								IrInstr.IrKind.Negative,
+								ctx.GetNewRegister(size),
+								reg
+							));
+							break;
+						case UnOpKind.Positive:
+							instructions.Add(new(
+								IrInstr.IrKind.Positive,
+								ctx.GetNewRegister(size),
+								reg
+							));
+							break;
+						default:
+							throw new Exception($"Generating `UnOpKind.{un.OP}` not implemented yet");
 					}
 				} break;
 			default:

--- a/csharp_compiler/IrGeneration/IrGenerator.cs
+++ b/csharp_compiler/IrGeneration/IrGenerator.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Nyapl.Parsing.Tree;
@@ -7,8 +9,143 @@ using Nyapl.Localizing;
 namespace Nyapl.IrGeneration;
 
 public class IrGenerator {
-	public IEnumerable<IrInstr> Generate(FunctionNode function) {
-		yield break;
+	private List<IrInstr> Generate(Context ctx, ExpressionNode expression) {
+		List<IrInstr> instructions = new();
+
+		switch (expression) {
+			case IntLiteralNode integer: {
+					instructions.Add(new(
+						IrInstr.IrKind.IntLiteral,
+						ctx.GetNewRegister(),
+						integer.Value
+					));
+				} break;
+			case IntrinsicNode intrinsic: {
+						var index = Array.IndexOf(ctx.Platform.Intrinsics.Keys.ToArray(), intrinsic.Name);
+						instructions.Add(new(
+							IrInstr.IrKind.LoadIntrinsic,
+							ctx.GetNewRegister(),
+							(ulong)index
+						));
+					} break;
+			case VarLookupNode lookup: {
+					var register = ctx.GetVariable(lookup.Name);
+					if (register == 0xFFFF_FFFF_FFFF_FFFF) {
+						// we are looking up a function
+						instructions.Add(new(
+							IrInstr.IrKind.LoadFunction,
+							ctx.GetNewRegister(),
+							ctx.GetFunction(lookup.Name)
+						));
+					} else {
+						// variable found
+						instructions.Add(new(
+							IrInstr.IrKind.Copy,
+							ctx.GetNewRegister(),
+							register
+						));
+					}
+				} break;
+			case CallNode call: {
+					instructions.AddRange(Generate(ctx, call.BaseExpr));
+					var baseReg = ctx.GetPreviousRegister();
+					var argRegs = new ulong[call.Arguments.Children.Count];
+					for (var i = 0; i < call.Arguments.Children.Count; i++) {
+						instructions.AddRange(Generate(ctx, call.Arguments.Children[i]));
+						argRegs[i] = ctx.GetPreviousRegister();
+					}
+					for (var i = 0; i < argRegs.Length; i++) {
+						instructions.Add(new(
+							IrInstr.IrKind.StoreParam,
+							(ulong)i,
+							argRegs[i]
+						));
+					}
+					instructions.Add(new(
+						IrInstr.IrKind.Call,
+						ctx.GetNewRegister(),
+						baseReg
+					));
+				} break;
+			case BinOpNode bin: {
+					instructions.AddRange(Generate(ctx, bin.LExpr));
+					var leftReg = ctx.GetPreviousRegister();
+					instructions.AddRange(Generate(ctx, bin.RExpr));
+					var rightReg = ctx.GetPreviousRegister();
+					switch (bin.OP) {
+						case BinOpKind.Multiply:
+							instructions.Add(new(
+								IrInstr.IrKind.Multiply,
+								ctx.GetNewRegister(),
+								leftReg,
+								rightReg
+							));
+							break;
+						case BinOpKind.Add:
+							instructions.Add(new(
+								IrInstr.IrKind.Add,
+								ctx.GetNewRegister(),
+								leftReg,
+								rightReg
+							));
+							break;
+						default:
+							throw new Exception($"Generating `BinOpKind.{bin.OP}` not implemented yet");
+					}
+				} break;
+			default:
+				throw new Exception($"Generate(ctx, {expression.GetType().Name}) not implemented yet");
+		}
+
+		return instructions;
+	}
+
+	private List<IrInstr> Generate(Context ctx, StatementNode statement) {
+		List<IrInstr> instructions = new();
+
+		switch (statement) {
+			case DeclareVarNode v: {
+				instructions.AddRange(Generate(ctx, v.Expression));
+				ctx.SetVariable(v.Name, ctx.GetPreviousRegister());
+			} break;
+			case ReturnStatementNode r: {
+				instructions.AddRange(Generate(ctx, r.Expression));
+				instructions.Add(new(
+					IrInstr.IrKind.Return,
+					ctx.GetPreviousRegister()
+				));
+			} break;
+			case UnsafeStatementNode u: {
+				foreach (var s in u.Body) {
+					instructions.AddRange(Generate(ctx, s));
+				}
+			} break;
+			default:
+				throw new Exception($"Generate(ctx, {statement.GetType().Name}) not implemented yet");
+		}
+
+		return instructions;
+	}
+
+	private List<IrInstr> Generate(Context ctx, FunctionNode function) {
+		List<IrInstr> instructions = new();
+
+		// add arguments to registers
+		ulong i = 0;
+		foreach (var param in function.Parameters) {
+			instructions.Add(new(
+				IrInstr.IrKind.LoadArgument,
+				ctx.GetNewRegister(),
+				i++
+			));
+			ctx.SetVariable(param.Name, ctx.GetPreviousRegister());
+		}
+
+		foreach (var statement in function.Body) {
+			instructions.AddRange(Generate(ctx, statement));
+		}
+
+		return instructions;
 	}
 
 	public IrList Generate(LocalizedFileNode file) {
@@ -18,10 +155,32 @@ public class IrGenerator {
 
 		foreach(var function in file.Functions) {
 			int fnIdx = instructions.Count;
-			instructions.AddRange(Generate(function));
+			Context ctx = new(file.Platform, file.Functions.Select(f => f.Name).ToArray());
+			instructions.AddRange(Generate(ctx, function));
 			functions[function.Name] = fnIdx;
 		}
 
 		return new(file.Platform, instructions.AsReadOnly(), functions.AsReadOnly());
+	}
+
+	private class Context {
+		public Context(Localizer.Platform platform, string[] functions) {
+			Platform = platform;
+			Functions = functions;
+		}
+
+		public Localizer.Platform Platform { get; }
+		public string[] Functions { get; }
+
+		private ulong currentRegister = 0;
+		private Dictionary<string, ulong> variables = new();
+
+		public ulong GetNewRegister() => currentRegister++;
+		public ulong GetPreviousRegister() => currentRegister - 1;
+
+		public ulong GetFunction(string name) => (ulong)Array.IndexOf(Functions, name);
+
+		public void SetVariable(string name, ulong register) => variables[name] = register;
+		public ulong GetVariable(string name) => variables.ContainsKey(name) ? variables[name] : 0xFFFF_FFFF_FFFF_FFFF;
 	}
 }

--- a/csharp_compiler/IrGeneration/IrInstr.cs
+++ b/csharp_compiler/IrGeneration/IrInstr.cs
@@ -2,8 +2,32 @@ namespace Nyapl.IrGeneration;
 
 public readonly struct IrInstr {
 	public IrKind Kind { get; }
+	public ulong Param0  { get; }
+	public ulong Param1  { get; }
+	public ulong Param2  { get; }
+
+	public IrInstr(IrKind kind, ulong param0 = 0, ulong param1 = 0, ulong param2 = 0) {
+		Kind = kind;
+		Param0 = param0;
+		Param1 = param1;
+		Param2 = param2;
+	}
+
+	public override string ToString() => $"{Kind} {Param0} {Param1} {Param2}";
 
 	public enum IrKind {
-		
+		Return,
+		StoreParam,
+		Call,
+
+		Copy,
+		LoadArgument,
+		LoadFunction,
+		LoadIntrinsic,
+
+		IntLiteral,
+
+		Multiply,
+		Add,
 	}
 }

--- a/csharp_compiler/IrGeneration/IrInstr.cs
+++ b/csharp_compiler/IrGeneration/IrInstr.cs
@@ -19,15 +19,17 @@ public readonly struct IrInstr {
 
 	}
 
-	public override string ToString() => $"{Kind,15} {ParamToString(Param0)} {ParamToString(Param1)} {ParamToString(Param2)}";
+	public override string ToString() => $"{Kind,20} {ParamToString(Param0)} {ParamToString(Param1)} {ParamToString(Param2)}";
 
 	public enum IrKind {
 		Return,
 		StoreParam,
+		StoreTupleSection,
 		Call,
 
 		Copy,
 		LoadArgument,
+		LoadTupleSection,
 		LoadFunction,
 		LoadIntrinsic,
 

--- a/csharp_compiler/IrGeneration/IrInstr.cs
+++ b/csharp_compiler/IrGeneration/IrInstr.cs
@@ -13,7 +13,13 @@ public readonly struct IrInstr {
 		Param2 = param2;
 	}
 
-	public override string ToString() => $"{Kind} {Param0} {Param1} {Param2}";
+	private static string ParamToString(ulong param) {
+		string tostr = $"{param:X16}";
+		return tostr.Substring(0, 4) + ":" + tostr.Substring(4, 4) + ":" + tostr.Substring(8, 4) + ":" + tostr.Substring(12, 4);
+
+	}
+
+	public override string ToString() => $"{Kind,15} {ParamToString(Param0)} {ParamToString(Param1)} {ParamToString(Param2)}";
 
 	public enum IrKind {
 		Return,

--- a/csharp_compiler/IrGeneration/IrInstr.cs
+++ b/csharp_compiler/IrGeneration/IrInstr.cs
@@ -22,10 +22,8 @@ public readonly struct IrInstr {
 	public override string ToString() => $"{Kind,20} {ParamToString(Param0)} {ParamToString(Param1)} {ParamToString(Param2)}";
 
 	public enum IrKind {
-		Return,
 		StoreParam,
 		StoreTupleSection,
-		Call,
 
 		Copy,
 		LoadArgument,
@@ -34,6 +32,12 @@ public readonly struct IrInstr {
 		LoadIntrinsic,
 
 		IntLiteral,
+		BoolLiteral,
+
+		JumpIfFalse,
+		JumpAlways,
+		Call,
+		Return,
 
 		Multiply,
 		Add,

--- a/csharp_compiler/IrGeneration/IrInstr.cs
+++ b/csharp_compiler/IrGeneration/IrInstr.cs
@@ -40,6 +40,16 @@ public readonly struct IrInstr {
 		Return,
 
 		Multiply,
+		Divide,
+		Modulo,
 		Add,
+		Subtract,
+
+		Equal,
+		NotEq,
+
+		Not,
+		Positive,
+		Negative,
 	}
 }

--- a/csharp_compiler/IrGeneration/IrInstr.cs
+++ b/csharp_compiler/IrGeneration/IrInstr.cs
@@ -1,0 +1,9 @@
+namespace Nyapl.IrGeneration;
+
+public readonly struct IrInstr {
+	public IrKind Kind { get; }
+
+	public enum IrKind {
+		
+	}
+}

--- a/csharp_compiler/IrGeneration/IrList.cs
+++ b/csharp_compiler/IrGeneration/IrList.cs
@@ -1,0 +1,17 @@
+using System.Collections.ObjectModel;
+
+using Nyapl.Localizing;
+
+namespace Nyapl.IrGeneration;
+
+public class IrList {
+	public Localizer.Platform Platform { get; }
+	public ReadOnlyCollection<IrInstr> Instructions { get; }
+	public ReadOnlyDictionary<string, int> Functions { get; }
+
+	public IrList(Localizer.Platform platform, ReadOnlyCollection<IrInstr> instructions, ReadOnlyDictionary<string, int> functions) {
+		Platform = platform;
+		Instructions = instructions;
+		Functions = functions;
+	}
+}

--- a/csharp_compiler/Localizing/LocalizedFileNode.cs
+++ b/csharp_compiler/Localizing/LocalizedFileNode.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
-using Nyapl.Localizing;
+using Nyapl.Parsing.Tree;
 
-namespace Nyapl.Parsing.Tree;
+namespace Nyapl.Localizing;
 
 public class LocalizedFileNode : AstNode {
 	public Localizer.Platform Platform { get; }

--- a/csharp_compiler/Localizing/Localizer.cs
+++ b/csharp_compiler/Localizing/Localizer.cs
@@ -48,7 +48,7 @@ public class Localizer {
 	}
 
 	public readonly struct Platform {
-		public readonly int PointerSize { get; init; }
+		public readonly ushort PointerSize { get; init; }
 		public readonly string[] Tags { get; init; }
 		public readonly Dictionary<string, Typ> Intrinsics { get; init; }
 

--- a/csharp_compiler/Parsing/Parser.cs
+++ b/csharp_compiler/Parsing/Parser.cs
@@ -65,7 +65,7 @@ public class Parser {
 			return new TupleNode(loc, list);
 		} else if (tokens.Match(KeywordKind.Intrinsic)) {
 			var loc = tokens.Take(KeywordKind.Intrinsic).Location;
-			tokens.Take(TokenKind.Bang);
+			tokens.Take(TokenKind.Colon);
 			var intrinsic = tokens.Take(TokenKind.Identifier).StrVal;
 			return new IntrinsicNode(loc, intrinsic);
 		}

--- a/csharp_compiler/Parsing/Tree/NoopStatementNode.cs
+++ b/csharp_compiler/Parsing/Tree/NoopStatementNode.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Nyapl.Parsing.Tree;
+
+public class NoopStatementNode : StatementNode {
+	public NoopStatementNode(SourceLoc location) {
+		Location = location;
+	}
+
+	public override ReadOnlyCollection<AstNode> GetChildren() {
+		List<AstNode> children = new();
+
+		return children.AsReadOnly();
+	}
+
+	public override string ToString() => "Nop";
+}

--- a/csharp_compiler/Typing/TypeChecker.cs
+++ b/csharp_compiler/Typing/TypeChecker.cs
@@ -667,6 +667,8 @@ public class TypeChecker {
 				switch (i.Type) {
 					case IntrinsicType.I32:
 						return 4;
+					case IntrinsicType.Bool:
+						return 1;
 					default:
 						throw new Exception($"Cannot get size for intrinsic: {i.Type}");
 				}

--- a/csharp_compiler/Typing/TypedFileNode.cs
+++ b/csharp_compiler/Typing/TypedFileNode.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+using Nyapl.Parsing.Tree;
+using Nyapl.Localizing;
+
+namespace Nyapl.Typing;
+
+public class TypedFileNode : AstNode {
+	public Localizer.Platform Platform { get; }
+	public ReadOnlyCollection<FunctionNode> Functions { get; }
+	public ReadOnlyCollection<TypeDefNode> TypeDefs { get; }
+	public TypeChecker.Context Context { get; }
+
+	public TypedFileNode(SourceLoc location, Localizer.Platform platform, ReadOnlyCollection<FunctionNode> functions, ReadOnlyCollection<TypeDefNode> typeDefs, TypeChecker.Context context) {
+		Location = location;
+		Platform = platform;
+		Functions = functions;
+		TypeDefs = typeDefs;
+		Context = context;
+	}
+
+	public override ReadOnlyCollection<AstNode> GetChildren() {
+		List<AstNode> children = new();
+
+		children.AddRange(TypeDefs);
+		children.AddRange(Functions);
+
+		return children.AsReadOnly();
+	}
+
+	public override string ToString() => "TypedFile";
+}

--- a/test.nya
+++ b/test.nya
@@ -16,9 +16,13 @@ fn [stdio] main(): i32 {
 	let (_, _, item_2) = tuple;
 	if true {
 		return 50;
+	} elif false {
+		return 60;
+	} else {
+		return 5;
 	}
 
-	return item_2;
+	// return item_2;
 }
 
 fn get_tuple(a: i32, b: i32): (i32, fn [stdio] (i32): (), i32) {

--- a/test.nya
+++ b/test.nya
@@ -11,5 +11,16 @@ platform {
 fn [stdio] main(): i32 {
 	let v = write_num(6 * 10 + 9);
 
-	return 20;
+	let tuple = get_tuple(5, 7);
+
+	let (_, _, item_2) = tuple;
+	if true {
+		return 50;
+	}
+
+	return item_2;
+}
+
+fn get_tuple(a: i32, b: i32): (i32, fn [stdio] (i32): (), i32) {
+	return (a, write_num, b);
 }

--- a/test.nya
+++ b/test.nya
@@ -14,17 +14,17 @@ fn [stdio] main(): i32 {
 	let tuple = get_tuple(5, 7);
 
 	let (_, _, item_2) = tuple;
-	if true {
+	if item_2 == 5 {
 		return 50;
-	} elif false {
+	} elif !(item_2 != 6) {
 		return 60;
 	} else {
-		return 5;
+		return 5 / 6 % 3 - 2;
 	}
 
 	// return item_2;
 }
 
 fn get_tuple(a: i32, b: i32): (i32, fn [stdio] (i32): (), i32) {
-	return (a, write_num, b);
+	return (-a, write_num, +b);
 }

--- a/test.nya
+++ b/test.nya
@@ -9,7 +9,11 @@ platform {
 }
 
 fn [stdio] main(): i32 {
-	let v = write_num(6 * 10 + 9);
+	fn nested(): i32 {
+		return 6;
+	}
+
+	let v = write_num(nested() * 10 + 9);
 
 	let tuple = get_tuple(5, 7);
 

--- a/test.nya
+++ b/test.nya
@@ -10,7 +10,10 @@ platform {
 
 fn [stdio] main(): i32 {
 	fn nested(): i32 {
-		return 6;
+		fn double(): i32 {
+			return 5;
+		}
+		return double();
 	}
 
 	let v = write_num(nested() * 10 + 9);

--- a/test.nya
+++ b/test.nya
@@ -9,7 +9,7 @@ platform {
 }
 
 fn [stdio] main(): i32 {
-	let v = write_num(0);
+	let v = write_num(6 * 10 + 9);
 
 	return 20;
 }

--- a/test.nya
+++ b/test.nya
@@ -2,7 +2,7 @@ platform {
 	[simulator] {
 		fn [stdio] write_num(value: i32): () {
 			unsafe [stdio] {
-				return intrinsic!write_num(value);
+				return intrinsic:write_num(value);
 			}
 		}
 	}


### PR DESCRIPTION
Pull request for the IR generation feature

# TODO:

- [x] pass type sizing information along into the ir generator
- [x] store register sizing in IR
- [x] implement IR generation for tuple construction
- [x] implement IR generation for tuple destruction
- [x] implement IR generation for `if`
- [x] implement IR generation for all other kinds of expressions (I think this is done)
- [x] implement handling for nested functions
    - maybe rename a function `bar` nested in `foo` into `foo/bar` internally and move it into global scope for the purpose of IR generation? the typechecker should've already done scope testing for it, and `/` is not allowed in function names, so we should be fine to move them out into global scope like that, would require refactoring part of the typechecker